### PR TITLE
feat: クロップ条件画像が見つからない場合は画像をスキップ

### DIFF
--- a/src/crop_processor.py
+++ b/src/crop_processor.py
@@ -18,6 +18,7 @@ class CropResult:
     start_y: int
     end_y: int
     match_count: int
+    should_save: bool = True
     warning: Optional[str] = None
 
 
@@ -116,13 +117,14 @@ class CropProcessor:
         warning: Optional[str] = None
 
         if match_count == 0:
-            # No match: return original image with warning
-            warning = "条件画像が見つかりませんでした。元画像を保存します。"
+            # No match: skip saving this image
+            warning = "条件画像が見つかりませんでした。この画像はスキップします。"
             return CropResult(
                 image=image,
                 start_y=0,
                 end_y=height,
                 match_count=0,
+                should_save=False,
                 warning=warning,
             )
         elif match_count == 1:

--- a/src/main.py
+++ b/src/main.py
@@ -68,15 +68,18 @@ def process_video(
                 if detector.detect(prev_frame, frame):
                     # Apply cropping if enabled
                     output_image = frame
+                    should_save = True
                     if crop_processor is not None:
                         crop_result = crop_processor.crop(frame)
                         output_image = crop_result.image
+                        should_save = crop_result.should_save
                         if crop_result.warning:
                             reporter.error(crop_result.warning)
 
-                    # Save the image
-                    writer.save(output_image, frame_num, loader.fps)
-                    detected_count += 1
+                    # Save the image (skip if crop condition not matched)
+                    if should_save:
+                        writer.save(output_image, frame_num, loader.fps)
+                        detected_count += 1
 
             prev_frame = frame
             reporter.update(frame_num + 1, detected_count)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -296,8 +296,8 @@ class TestCropProcessingFlow:
         call_kwargs = MockCropProcessor.call_args[1]
         assert call_kwargs["scan_area"] == (90, 0, 110, 200)
 
-    def test_crop_fallback_when_no_marker_found(self, tmp_path: Path) -> None:
-        """Test that original image is saved when condition image is not found."""
+    def test_crop_skip_when_no_marker_found(self, tmp_path: Path) -> None:
+        """Test that image is skipped when condition image is not found."""
         frame1 = np.zeros((100, 100, 3), dtype=np.uint8)
         frame2 = np.full((100, 100, 3), 128, dtype=np.uint8)  # No markers
 
@@ -319,12 +319,12 @@ class TestCropProcessingFlow:
             scan_area=None,
         )
 
-        assert detected_count == 1
+        # Image should be skipped when no marker is found
+        assert detected_count == 0
 
-        # Original image should be saved (not cropped)
+        # No images should be saved
         output_images = list(output_dir.glob("*.png"))
-        saved_img = cv2.imread(str(output_images[0]))
-        assert saved_img.shape[0] == 100  # Original height
+        assert len(output_images) == 0
 
     def test_crop_warning_displayed_on_single_marker(self, tmp_path: Path) -> None:
         """Test that warning is displayed when only one marker is found."""


### PR DESCRIPTION
## Summary
- `--crop-image`オプション使用時、条件画像がフレーム内で見つからなかった場合に画像を保存せずスキップするように変更
- `CropResult`に`should_save`フラグを追加し、`match_count == 0`の場合は`False`を設定
- `main.py`で`should_save`フラグを確認し、`False`の場合は保存をスキップ

## Test plan
- [x] `CropProcessor`の単体テストが全てパスすることを確認
- [x] 統合テストが全てパスすることを確認
- [x] 条件画像が見つからない場合に画像がスキップされることを確認するテストを追加

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)